### PR TITLE
Allow to link with mtl 2.1.*.

### DIFF
--- a/driver-hdbc-odbc/haskelldb-hdbc-odbc.cabal
+++ b/driver-hdbc-odbc/haskelldb-hdbc-odbc.cabal
@@ -14,7 +14,7 @@ Category: Database
 
 Library
   Build-depends: 
-    mtl >= 1 && < 2.2, 
+    mtl >= 1 && < 3, 
     haskelldb >= 2 && < 3,
     haskelldb-hdbc >= 2 && < 3,
     HDBC >= 2 && < 3,

--- a/driver-hdbc-postgresql/haskelldb-hdbc-postgresql.cabal
+++ b/driver-hdbc-postgresql/haskelldb-hdbc-postgresql.cabal
@@ -14,7 +14,7 @@ Category: Database
 
 Library
   Build-depends: 
-    mtl >= 1 && < 2.2, 
+    mtl >= 1 && < 3, 
     haskelldb >= 2 && < 3,
     haskelldb-hdbc >= 2 && < 3,
     HDBC >= 2 && < 3,

--- a/driver-hdbc-sqlite3/haskelldb-hdbc-sqlite3.cabal
+++ b/driver-hdbc-sqlite3/haskelldb-hdbc-sqlite3.cabal
@@ -14,7 +14,7 @@ Category: Database
 
 Library
   Build-depends: 
-    mtl >= 1 && < 2.2, 
+    mtl >= 1 && < 3, 
     haskelldb >= 2 && < 3,
     haskelldb-hdbc >= 2 && < 3,
     HDBC >= 2 && < 3, HDBC-sqlite3 >= 2 && < 3,

--- a/driver-hdbc/haskelldb-hdbc.cabal
+++ b/driver-hdbc/haskelldb-hdbc.cabal
@@ -13,7 +13,7 @@ Description: HaskellDB requires this driver to work with any of HDBC's drivers.
 Category: Database
 
 Library
-  Build-depends: mtl >= 1 && < 2.2, haskelldb >= 2.2 && < 3, HDBC >= 2 && < 3, convertible >= 1.0.1 && < 2
+  Build-depends: mtl >= 1 && < 3, haskelldb >= 2.2 && < 3, HDBC >= 2 && < 3, convertible >= 1.0.1 && < 2
   Build-depends: base >= 3 && < 5, containers >= 0.2 && < 1, old-time >= 1 && < 2
   Extensions: ExistentialQuantification,
             OverlappingInstances,

--- a/haskelldb.cabal
+++ b/haskelldb.cabal
@@ -14,7 +14,7 @@ Description: This library allows you to build SQL SELECT, INSERT, UPDATE, and DE
 Category: Database
 
 Library
-  Build-depends: mtl >= 1.1 && < 2.2, 
+  Build-depends: mtl >= 1.1 && < 3, 
                  base >= 3 && < 5, 
                  pretty >= 1 && < 2, 
                  old-time >= 1 && < 2, 


### PR DESCRIPTION
'mtl-2.1.1' package is included in newest Haskell Platform 2012.2.0.0.
