### PR TITLE
Experimental implementation to support tupled Query Relation types and tupled result Record types

### DIFF
--- a/src/Database/HaskellDB/HDBRec.hs
+++ b/src/Database/HaskellDB/HDBRec.hs
@@ -176,6 +176,8 @@ instance (FieldTag f,ShowLabels r) => ShowLabels (RecCons f a r) where
     recordLabels ~x@(RecCons _ r) = consFieldName x : recordLabels r
 instance ShowLabels r => ShowLabels (Record r) where
     recordLabels r = recordLabels (r RecNil)
+instance (ShowLabels r0, ShowLabels r1) => ShowLabels (r0, r1) where
+    recordLabels (r0, r1) = recordLabels r0 ++ recordLabels r1
 
 -- * Showing rows 
 

--- a/src/Database/HaskellDB/Query.hs
+++ b/src/Database/HaskellDB/Query.hs
@@ -150,6 +150,10 @@ instance ProjectRec RecNil RecNil
 instance (ProjectExpr e, ProjectRec r er) => 
   ProjectRec (RecCons f (e a) r) (RecCons f (Expr a) er)
 
+instance ProjectRec r1 er1 => ProjectRec (RecNil, r1) (RecNil, er1)
+instance ProjectRec (r, r1) (er, er1)
+         => ProjectRec (RecCons f (e a) r, r1) (RecCons f (Expr a) er, er1)
+
 -----------------------------------------------------------
 -- Record operators
 -----------------------------------------------------------
@@ -833,3 +837,5 @@ instance ToPrimExprs RecNil where
 instance (ExprC e, ToPrimExprs r) => ToPrimExprs (RecCons l (e a) r) where
     toPrimExprs ~(RecCons e r) = primExpr e : toPrimExprs r
 
+instance (ToPrimExprs r0, ToPrimExprs r1) => ToPrimExprs (r0, r1) where
+  toPrimExprs (r0, r1) = toPrimExprs r0 ++ toPrimExprs r1


### PR DESCRIPTION
Now, we can write queries like below. 
But, There is a problem not to get column value when the same column name exists more than two times in one joined form. 

type RelX = RecCons X0 (Expr p0) (RecCons X1 ... )
type RelY = RecCons Y0 (Expr q0) (RecCons Y1 ... )

type RecordX = RecCons X0 p0 (RecCons X1 ... )
type RecordY = RecCons Y0 q0 (RecCons Y1 ... )

tableX :: Table RelX
tableY :: Table RelY

join0 :: Query (Rel (RelX, RelY))
join0 =  do
  tx <- table tableX
  ty <- table tableY
  ...
  project $ (,) <$> copyAll tx <*> copyAll ty

queryJoin0 :: Database -> IO [Record (RecordX, RecordY)]
queryJoin0 =  (`query` join0)
