### PR TITLE
[Postgresql] Quote literals and escape strings by default

### DIFF
--- a/src/Database/HaskellDB/Sql/PostgreSQL.hs
+++ b/src/Database/HaskellDB/Sql/PostgreSQL.hs
@@ -53,6 +53,7 @@ postgresqlSpecial op q = defaultSqlSpecial generator op q
 postgresqlLiteral :: Literal -> String
 postgresqlLiteral (DateLit d) = defaultSqlQuote generator (formatCalendarTime defaultTimeLocale fmt d)
     where fmt = iso8601DateFormat (Just "%H:%M:%S %Z")
+postgresqlLiteral (StringLit l) = "E" ++ (defaultSqlLiteral generator (StringLit l))
 postgresqlLiteral l = defaultSqlLiteral generator l
 
 postgresqlType :: FieldType -> SqlType


### PR DESCRIPTION
Not sure if this should be merged, but I thought I'd give the option.

The problem is that if someone decides in their database schema to use identifiers (for tables or columns) which are psql-reserved keywords (such as `user` or `group`), haskelldb will currently fail to generate the proper queries. These identifiers must be quoted with `"`. This patch quotes **all** identifiers to be on the safe side, perhaps it could be adapted to only quote psql-reserved keywords.

The second change is to prepend `E` to all string literals, thus enabling proper interpretation of control characters.

Credits for this code should go to @chrisdone.