### PR TITLE
Mark list expressions as constant.

### DIFF
--- a/src/Database/HaskellDB/Sql/Default.hs
+++ b/src/Database/HaskellDB/Sql/Default.hs
@@ -462,6 +462,7 @@ defaultSqlExpr gen e =
       CastExpr typ e1 -> CastSqlExpr typ (sqlExpr gen e1)
   where
     isConstAttr :: PrimExpr -> Bool
+    isConstAttr (ListExpr _) = True
     isConstAttr (ConstExpr _) = True
     isConstAttr (AttrExpr _) = True
     isConstAttr _ = False


### PR DESCRIPTION
This prevents lists in expressions from being rendered with double parentheses surrounding them, which confuses PostgreSQL and causes it to think they're supposed to be records.

The issue I encountered was with the `IN` operator, where expressions would be formulated as

```
<column> IN ((1,2,3,…))
```
One set of parentheses is already added by `ppSqlExpr` in `Database.HaskellDB.Sql.Print` and the second, which this commit removes, was added by `defaultSqlExpr` in `Database.HaskellDB.Sql.Default`.

Hopefully this doesn't break something else, but as far as I can see lists can only be used as constant expressions.