### PR TITLE
GHC 9.8 update #30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@
 \.setup-config
 # standard cabal build dir, might not be boring for everybody
 dist/
+dist-newstyle/
 # autotools
 (^|/)autom4te\.cache($|/)
 (^|/)config\.(log|status)$
@@ -79,6 +80,7 @@ dist/
 (^|/)(\+|,)
 (^|/)vssver\.scc$
 \.swp$
+\.swo$
 (^|/)MT($|/)
 (^|/)\{arch\}($|/)
 (^|/).arch-ids($|/)

--- a/haskelldb.cabal
+++ b/haskelldb.cabal
@@ -1,6 +1,6 @@
 Name: haskelldb
-Version: 2.2.4
-Cabal-version: >= 1.6
+Version: 2.2.4.1
+Cabal-version: >= 1.8
 Build-type: Simple
 Homepage: https://github.com/m4dc4p/haskelldb
 Copyright: The authors

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> { }, ... }:
+
+pkgs.mkShell {
+  inputsFrom  = [
+    (pkgs.haskell.packages.ghc810.callCabal2nix "haskelldb-2.2.4.1" ./. { }).env 
+  ];
+  buildInputs = [
+    pkgs.cabal-install
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 
 pkgs.mkShell {
   inputsFrom  = [
-    (pkgs.haskell.packages.ghc90.callCabal2nix "haskelldb-2.2.4.1" ./. { }).env 
+    (pkgs.haskell.packages.ghc98.callCabal2nix "haskelldb-2.2.4.1" ./. { }).env 
   ];
   buildInputs = [
     pkgs.cabal-install

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 
 pkgs.mkShell {
   inputsFrom  = [
-    (pkgs.haskell.packages.ghc810.callCabal2nix "haskelldb-2.2.4.1" ./. { }).env 
+    (pkgs.haskell.packages.ghc90.callCabal2nix "haskelldb-2.2.4.1" ./. { }).env 
   ];
   buildInputs = [
     pkgs.cabal-install

--- a/src/Database/HaskellDB/DBDirect.hs
+++ b/src/Database/HaskellDB/DBDirect.hs
@@ -32,7 +32,6 @@ import System.Environment (getArgs, getProgName, )
 import System.Exit (exitFailure, )
 import System.IO (hPutStrLn, stderr, )
 
-import Control.Monad.Error () -- Monad instance for Either
 import Control.Monad (when, )
 import Data.List (intersperse, )
 

--- a/src/Database/HaskellDB/DBSpec/PPHelpers.hs
+++ b/src/Database/HaskellDB/DBSpec/PPHelpers.hs
@@ -76,7 +76,7 @@ Generalization of 'words' and 'lines' to any separating character set.
 -}
 split :: Eq a => (a -> Bool) -> [a] -> [[a]]
 split p =
-   foldr (\ x yt@ ~(y:ys) -> (if p x then ([]:yt) else ((x:y):ys)) ) [[]]
+   foldr (\ x yt@(~(y:ys)) -> (if p x then ([]:yt) else ((x:y):ys)) ) [[]]
 
 checkChars s	= map replace s
 		where

--- a/src/Database/HaskellDB/Database.hs
+++ b/src/Database/HaskellDB/Database.hs
@@ -243,7 +243,7 @@ describe = dbDescribe
 transaction :: Database -- ^ Database
 	    -> IO a -- ^ Action to run
 	    -> IO a 
-transaction = dbTransaction
+transaction db x = dbTransaction db x
 
 -- | Commit any pending data to the database.
 commit :: Database -- ^ Database

--- a/src/Database/HaskellDB/DriverAPI.hs
+++ b/src/Database/HaskellDB/DriverAPI.hs
@@ -54,7 +54,7 @@ defaultdriver =
 
 -- | Can be used by drivers to get option values from the given
 --   list of name, value pairs.
-getOptions ::Monad m => [String] -- ^ names of options to get
+getOptions ::MonadFail m => [String] -- ^ names of options to get
            -> [(String,String)] -- ^ options given
            -> m [String] -- ^ a list of the same length as the first argument
                          --   with the values of each option. Fails in the given
@@ -68,7 +68,7 @@ getOptions (x:xs) ys =
 -- | Can be used by drivers to get option values from the given
 --   list of name, value pairs.
 --   It is intended for use with the 'requiredOptions' value of the driver.
-getAnnotatedOptions :: Monad m =>
+getAnnotatedOptions :: MonadFail m =>
               [(String,String)] -- ^ names and descriptions of options to get
            -> [(String,String)] -- ^ options given
            -> m [String] -- ^ a list of the same length as the first argument
@@ -78,7 +78,7 @@ getAnnotatedOptions opts = getOptions (map fst opts)
 
 -- | Gets an 'SqlGenerator' from the "generator" option in the given list.
 --   Currently available generators: "mysql", "postgresql", "sqlite", "default"
-getGenerator :: Monad m => 
+getGenerator :: MonadFail m => 
                 [(String,String)] -- ^ options given
            -> m SqlGenerator -- ^ An SQL generator. If there was no
                              --   "generator" option, the default is used.

--- a/src/Database/HaskellDB/DriverAPI.hs
+++ b/src/Database/HaskellDB/DriverAPI.hs
@@ -1,4 +1,11 @@
-{-# LANGUAGE ExistentialQuantification, Rank2Types #-}
+{-# LANGUAGE ExistentialQuantification, Rank2Types, CPP #-}
+
+-- Control.Monad.Fail import is redundant since GHC 8.8.1 and base 4.13
+#if !MIN_VERSION_base(4,13,0)
+import Control.Monad.Fail (MonadFail)
+fail = MonadFail
+#endif
+
 -----------------------------------------------------------
 -- |
 -- Module      :  DriverAPI

--- a/test.nix
+++ b/test.nix
@@ -1,0 +1,38 @@
+{ pkgs ? import <nixpkgs> { }, ... }:
+
+let 
+  pgData   = "./pgData";
+  testPkgs = ghc: [ 
+    ghc.HUnit 
+    ghc.regex-compat 
+    ghc.HDBC
+    ghc.HDBC-postgresql
+  ];
+in
+
+pkgs.mkShell {
+  inputsFrom  = [
+    (pkgs.haskell.packages.ghc90.callCabal2nix "haskelldb-2.2.4.1" ./. { }).env 
+    (pkgs.haskell.packages.ghc90.ghcWithPackages testPkgs)
+  ];
+  buildInputs = [
+    pkgs.cabal-install
+    pkgs.postgresql
+  ];
+  shellHook = ''
+    cabal build
+
+    echo "Setting up PostgreSQL..."
+    export PGDATA="$(realpath ${pgData})"
+    echo "Initializing database cluster in local directory at $PGDATA, will run db server with current user $(whoami)"
+    if [ -d "$PGDATA" ]; then
+      rm -rf "$PGDATA"
+    fi
+    mkdir -p "$PGDATA"
+
+    initdb --auth-local=trust --auth-host=trust --pgdata "$PGDATA" -c "unix_socket_directories=$PGDATA" 
+    pg_ctl --pgdata="$PGDATA" -l "$PGDATA/logfile" start 
+
+    trap "echo 'Stopping PostgreSQL'; pg_ctl --pgdata=$PGDATA -w stop" EXIT
+  '';
+}


### PR DESCRIPTION
Minor changes to syntax to mirror upgrade to newer GHC. Did it incrementally by pinning GHC compiler versions inside Nix shell `shell.nix`. To build simply run `nix-shell` then `cabal build` inside the shell.

I have tried to setup full testing environment in Nix shell, which builds the code and runs `postgres` service in `test.nix`. This works very nicely and creates the test database automatically.
Still need to manually build the test scripts once inside the shell, to allow linking to complete (should be replaced with `nix develop` or flakes, for example). To build the tests:
```
nix-shell test.nix

[nixshell:~/haskelldb]$ cabal v2-exec -- ghc --make test/DescDB1.hs
[nixshell:~/haskelldb]$ ./test/DescDB1
[nixshell:~/haskelldb]$ cabal v2-exec -- ghc --make test/test-hdbc-postgresql.hs
[nixshell:~/haskelldb]$ ./test/test-hdbc-postgresql.hs
```
and so on for all the different tests. Alternatively we can change the Makefile and call it inside the Nix shell.

However we have an issue with  `haskelldb-hdbc-postgresql` and the other adapters in the actual test files, I worry this is a chicken and egg problem where we need to upgrade  `haskelldb-hdbc-postgresql` also just to test the upgrade of `haskelldb`. I'm not sure.

> Could not find module ‘Database.HaskellDB.HDBC.PostgreSQL’
>    Perhaps you meant
>      Database.HaskellDB.Sql.PostgreSQL (from haskelldb-2.2.4.1)

This is all somwehat opinionated however I hope the code updates will be useful, maybe you can merge them and release them. Alternatively, I never made or maintained a Hackage release before, but i'd be happy to try.